### PR TITLE
fix: swiping highlights the correct tab in input-output-wrapper

### DIFF
--- a/client/components/edit-page/input-output-wrapper.js
+++ b/client/components/edit-page/input-output-wrapper.js
@@ -86,6 +86,8 @@ class InputOutputWrapper extends React.Component {
             </Tabs>
           </AppBar>
           <SwipeableViews
+            resistance
+            onSwitching={index => this.handleChange(null, index)}
             axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
             index={this.state.value}
             className={classes.swipe}

--- a/client/components/edit-page/results.js
+++ b/client/components/edit-page/results.js
@@ -8,9 +8,9 @@ import TableBody from '@material-ui/core/TableBody'
 const Results = ({testCases, outputs}) => {
   testCases = testCases ? testCases.trim().split('\n') : ['']
   if (typeof outputs === 'string') {
-    return outputs
+    return <p>{outputs}</p>
   } else if (outputs.length === 0) {
-    return 'No Output'
+    return <p>No output</p>
   }
 
   const type = text =>


### PR DESCRIPTION
can be tested on the phone